### PR TITLE
Fullscreen mode - partial fix for linux

### DIFF
--- a/src/fullscreenwindow.cpp
+++ b/src/fullscreenwindow.cpp
@@ -26,11 +26,4 @@ FullScreenWindow::FullScreenWindow(QWidget *parent, GlWidget *gl3widget)
     fullScreenLayout->addWidget(glwidget);
     setLayout(fullScreenLayout);
     glwidget->update();
-
-#ifdef __linux__
-    setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
-    show();
-#else
-    showFullScreen();
-#endif
 }

--- a/src/fullscreenwindow.cpp
+++ b/src/fullscreenwindow.cpp
@@ -1,7 +1,9 @@
 #include <QHBoxLayout>
 #include <QApplication>
+#include <QDesktopWidget>
 #include <QDebug>
 #include <QShortcut>
+#include <QScreen>
 
 #include "fullscreenwindow.h"
 #include "globals.h"
@@ -11,21 +13,24 @@ FullScreenWindow::FullScreenWindow(QWidget *parent, GlWidget *gl3widget)
 {
     glwidget = gl3widget;
 
-    // Included gere for testing in a windowed mode
-    /*
-    int nWidth = 1200;
-    int nHeight = 800;
+#ifdef __linux__
+    currentScreen = availableScreens.at(QApplication::desktop()->screenNumber(this));
     if (parent != nullptr)
-        setGeometry(parent->x() + parent->width() / 2 - nWidth / 2,
-                    parent->y() + parent->height() / 2 - nHeight / 2,
-                    nWidth, nHeight);
+        setGeometry(currentScreen->geometry());
     else
-        resize(nWidth, nHeight);
-    */
+        resize(currentScreen->geometry().width(), currentScreen->geometry().height());
+#endif
 
     QHBoxLayout *fullScreenLayout = new QHBoxLayout(this);
     fullScreenLayout->setContentsMargins(0, 0, 0, 0);
     fullScreenLayout->addWidget(glwidget);
     setLayout(fullScreenLayout);
     glwidget->update();
+
+#ifdef __linux__
+    setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
+    show();
+#else
+    showFullScreen();
+#endif
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3876,21 +3876,9 @@ void MainWindow::updateScreenRatio()
  */
 void MainWindow::on_actionFull_Screen_triggered()
 {
-
-#ifdef __linux__
-    QMessageBox::warning(this, "Apologies", "Full screen doesn't currently work on Linux due to limitations of the QWidget::showFullScreen() call. Sorry about that.");
-    return;
-    //fullScreenDialog->setWindowFlags( Qt::X11BypassWindowManagerHint);
-    // fullScreenDialog->setWindowFlags(Qt::X11BypassWindowManagerHint | Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
-    //fullScreenDialog->showMaximized();
-    //fullScreenDialog->setWindowState(Qt::WindowFullScreen);
-    //fullScreenDialog->show();
-#else
     if (isGLFullScreen == false)
     {
         fullScreenDialog = new FullScreenWindow(this, gl3widget);
-
-        fullScreenDialog->showFullScreen();
         isGLFullScreen = true;
 
         //qDebug() << "[Full Screen Mode] Opening full screen mode";
@@ -3905,5 +3893,4 @@ void MainWindow::on_actionFull_Screen_triggered()
 
         //qDebug() << "[Full Screen Mode] Closing full screen mode";
     }
-#endif
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -3881,6 +3881,12 @@ void MainWindow::on_actionFull_Screen_triggered()
         fullScreenDialog = new FullScreenWindow(this, gl3widget);
         isGLFullScreen = true;
 
+#ifdef __linux__
+        fullScreenDialog->setWindowFlags(Qt::WindowStaysOnTopHint | Qt::FramelessWindowHint);
+        fullScreenDialog->show();
+#else
+        fullScreenDialog->showFullScreen();
+#endif
         //qDebug() << "[Full Screen Mode] Opening full screen mode";
     }
     else


### PR DESCRIPTION
Changed code so in linux the fullscreen mode opens a decorated (windows title only) dialog as the QWidget::showFullScreen() function does not appear work in X11 clients. See http://doc.qt.io/qt-5/qwidget.html#showFullScreen. 